### PR TITLE
Add Authelia OIDC documentation

### DIFF
--- a/docs/self-hosting/installation.md
+++ b/docs/self-hosting/installation.md
@@ -36,7 +36,7 @@ $ git clone https://github.com/linkwarden/linkwarden.git
 $ cd linkwarden
 ```
 
-#### 3. Configure the Environment Variables
+#### 2. Configure the Environment Variables
 
 Inside the `/linkwarden` folder, create a file named `.env`, open it and paste the following text inside it:
 
@@ -50,7 +50,7 @@ The only thing you **MUST** change here is `YOUR_POSTGRES_PASSWORD` and `VERY_SE
 
 The `NEXTAUTH_URL` should be changed to your domain name _only if you are hosting it somewhere else_.
 
-#### 4. Run it!
+#### 3. Run it!
 
 In the main folder (where you create the .env file) simply run the following:
 
@@ -76,6 +76,7 @@ The Manual Installation is targeted towards a more technical audience, to take a
 - Node.js
 - Yarn
 - Postgres
+- [Monolith](https://github.com/Y2Z/monolith)
 
 #### 1. Clone the Linkwarden repository
 

--- a/docs/self-hosting/sso-oauth.md
+++ b/docs/self-hosting/sso-oauth.md
@@ -60,6 +60,42 @@ The variables you need to configure to enable support for Auth0 (OIDC):
 | AUTH0_CLIENT_ID           | -       | Client ID                                                                            |
 | AUTH0_CLIENT_SECRET       | -       | Client Secret.                                                                       |
 
+## Authelia
+
+The variables you need to configure to enable support for Authelia (OIDC).
+
+| Environment Variable          | Default | Description                                                                             |
+| ----------------------------- | ------- | --------------------------------------------------------------------------------------- |
+| NEXT_PUBLIC_AUTHELIA_ENABLED  | -       | If set to true, Authelia will be enabled and you'll need to define the variables below. |
+| AUTHELIA_WELLKNOWN_URL        | -       | https://{{authelia.domain.com}}/.well-known/openid-configuration                          |
+| AUTHELIA_CLIENT_ID            | -       | Client ID                                                                               |
+| AUTHELIA_CLIENT_SECRET        | -       | Client Secret. (Random Password from command below)                                                                         |
+
+Generate the client secret with 
+```bash
+docker exec -it authelia authelia crypto hash generate pbkdf2 --variant sha512 --random --random.length 72 --random.charset rfc3986
+```
+The `Random Password` should be used for the `AUTHELIA_CLIENT_SECRET` variable in linkwarden & the `Digest` should be used for `client_secret` in th Authelia config below.
+
+Authelia config should be as follows:
+
+```yaml
+      - client_id: linkwarden
+        client_name: Linkwarden
+        client_secret: {{Digest from command above}}
+        public: false
+        authorization_policy: one_factor
+        consent_mode: implicit
+        scopes:
+          - openid
+          - groups
+          - email
+          - profile
+        redirect_uris:
+          - https://{{linkwarden.domain.com}}/api/v1/auth/callback/authelia
+        userinfo_signed_response_alg: none
+```
+
 ## Authentik
 
 The variables you need to configure to enable support for Authentik (OIDC):


### PR DESCRIPTION
Looked at the relevant issue [here](https://github.com/linkwarden/linkwarden/issues/382) & the [PR adding authelia support](https://github.com/linkwarden/linkwarden/pull/521) but couldn't see the redirect_uri specified anywhere so decided to flesh out the docs as Authelia is currently completely missing.