### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/docs/self-hosting/installation.md
+++ b/docs/self-hosting/installation.md
@@ -146,6 +146,12 @@ Keep in mind that you need to have Meilisearch running in the background before 
 yarn concurrently:start
 ```
 
+### Managed Hosting
+
+If you would rather not run a server yourself, Zenith hosts a managed Linkwarden instance for you, with storage, backups and a free subdomain included. A share of every subscription goes back to Linkwarden.
+
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/linkwarden)
+
 ### Troubleshooting
 
 There are a few common issues that you might encounter when setting up Linkwarden, here are some of them:


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Linkwarden to our marketplace, so this PR adds a small "Deploy with Zenith" badge under a new "Managed Hosting" heading in the self-hosting installation docs (links to https://zenith.hosting/host/linkwarden).

it is a docs-only change, six added lines in `docs/self-hosting/installation.md`. i put it at the end of the install options rather than at the top, since Linkwarden Cloud should stay the first thing people see.

we share a cut of revenue with the projects we host, so a Zenith subscription funds Linkwarden the same way. happy to explain if you're curious: hello@zenith.hosting
